### PR TITLE
fix REGEX to allow translation without entering an extra character

### DIFF
--- a/assets/js/fill_course_translation_table.js
+++ b/assets/js/fill_course_translation_table.js
@@ -13,7 +13,7 @@ textarea.addEventListener('input', function() {
     const origText = textarea.value;
     let resultText = origText;
     
-    const _3dCourse = /(?<subject>[a-zA-Z]{2,4})\s*(?<number>\d{3})(?<after>[^\d])/g;
+    const _3dCourse = /(?<subject>[a-zA-Z]{2,4})\s*(?<number>\d{3})(?<after>[^\d]|$)/g
     const matches = origText.matchAll(_3dCourse);
 
     for (const match of matches) {


### PR DESCRIPTION
Original behavior: 
Entering the course title followed by the 3 digit ID would not display the translated pattern without entering an extra character (e.g. whitespace or letters)

Modified behavior:
Entering the course title followed by the 3 digit ID would display the translated pattern without the need for entering an extra character